### PR TITLE
Fix typo

### DIFF
--- a/presets/sortable/README.md
+++ b/presets/sortable/README.md
@@ -271,7 +271,7 @@ By default, the [Keyboard](../../api-documentation/sensors/keyboard.md) sensor m
 
 The sortable preset ships with a custom coordinate getter function for the keyboard sensor that moves the active draggable to the closest sortable element in a given direction within the same `DndContext`.
 
-To use it, import the `sortableKeyboardCoordinates` coordinate getter function provided by `@dnd-kit/sortable`, and pass it to the `coordiniateGetter` option of the Keyboard sensor.
+To use it, import the `sortableKeyboardCoordinates` coordinate getter function provided by `@dnd-kit/sortable`, and pass it to the `coordinateGetter` option of the Keyboard sensor.
 
 In this example, we'll also be setting up the [Pointer](../../api-documentation/sensors/pointer.md) sensor, which is the other sensor that is enabled by default on `DndContext` if none are defined. We use the `useSensor` and `useSensors` hooks to initialize the sensors:
 

--- a/presets/sortable/usesortable.md
+++ b/presets/sortable/usesortable.md
@@ -45,7 +45,7 @@ function SortableItem(props) {
 
 ### Listeners
 
-The `listeners` property contains the a[ctivator event handlers](../../api-documentation/sensors/#activators) for each [Sensor](../../api-documentation/sensors/) that is defined on the parent [`DndContext`](../../api-documentation/context-provider/#props) provider. 
+The `listeners` property contains the [activator event handlers](../../api-documentation/sensors/#activators) for each [Sensor](../../api-documentation/sensors/) that is defined on the parent [`DndContext`](../../api-documentation/context-provider/#props) provider. 
 
 It should be attached to the node\(s\) that you wish to use as the activator to begin a sort event. In most cases, that will be the same node as the one passed to `setNodeRef`, though not necessarily. For instance, when implementing a sortable element with a "drag handle", the ref should be attached to the parent node that should be sortable, but the listeners can be attached to the handle node instead.
 


### PR DESCRIPTION
I'm trying dnd-kit currently and I've found something looks mistake in docs.
This lib is so great. Thank you!