### PR TITLE
docs: changed striked link to normal link

### DIFF
--- a/presets/sortable/README.md
+++ b/presets/sortable/README.md
@@ -115,7 +115,7 @@ For most sortable lists, we recommend you use a [`DragOverlay`](../../api-docume
 
 The sortable preset builds on top of the primitives exposed by `@dnd-kit/core` to help building sortable interfaces.&#x20;
 
-The sortable preset exposes two main concepts: [~~`SortableContext`~~](./#sortable-context) and the [`useSortable`](./#usesortable) hook:
+The sortable preset exposes two main concepts: [`SortableContext`](./#sortable-context) and the [`useSortable`](./#usesortable) hook:
 
 * The `SortableContext` provides information via context that is consumed by the `useSortable` hook.
 * The `useSortable` hook is an abstraction that composes the [`useDroppable`](../../api-documentation/droppable/) and [`useDraggable`](../../api-documentation/draggable/) hooks:


### PR DESCRIPTION
Description:
          In sortable documentation, sortable context link is striked out. To fix that I am creating this PR.

<img width="1411" alt="Screenshot 2022-06-02 at 10 16 08 PM" src="https://user-images.githubusercontent.com/60533560/171682132-ba6cf96b-094e-47df-8031-9ab3ea79f798.png">
