### PR TITLE
Correction to the DndContext accessibility property

### DIFF
--- a/guides/accessibility.md
+++ b/guides/accessibility.md
@@ -211,9 +211,9 @@ function App() {
   
   return (
     <DndContext
-      accessibility={
-        announcements,
-      }
+      accessibility={{
+        announcements
+      }}
     >
 ```
 


### PR DESCRIPTION
the accessibility property takes an object that contains the announcements.