### PR TITLE
Update DndContext Props definition, references to "accessibility" prop 

### DIFF
--- a/api-documentation/context-provider/README.md
+++ b/api-documentation/context-provider/README.md
@@ -4,17 +4,17 @@
 
 ### Context provider
 
-In order for your your [Droppable](../droppable/) and [Draggable](../draggable/) components to interact with each other, you'll need to make sure that the part of your React tree that uses them is nested within  a parent `<DndContext>` component. The `<DndContext>` provider makes use of the [React Context API](https://reactjs.org/docs/context.html) to share data between draggable and droppable components and hooks.
+In order for your your [Droppable](../droppable/) and [Draggable](../draggable/) components to interact with each other, you'll need to make sure that the part of your React tree that uses them is nested within a parent `<DndContext>` component. The `<DndContext>` provider makes use of the [React Context API](https://reactjs.org/docs/context.html) to share data between draggable and droppable components and hooks.
 
 > React context provides a way to pass data through the component tree without having to pass props down manually at every level.
 
-Therefore, components that use [`useDraggable`](../draggable/usedraggable.md), [`useDroppable`](../droppable/usedroppable.md)  or [`DragOverlay`](../draggable/drag-overlay.md) will need to be nested within a `DndContext` provider.
+Therefore, components that use [`useDraggable`](../draggable/usedraggable.md), [`useDroppable`](../droppable/usedroppable.md) or [`DragOverlay`](../draggable/drag-overlay.md) will need to be nested within a `DndContext` provider.
 
- They don't need to be direct descendants, but, there does need to be a parent `<DndContext>` provider somewhere higher up in the tree.
+They don't need to be direct descendants, but, there does need to be a parent `<DndContext>` provider somewhere higher up in the tree.
 
 ```jsx
-import React from 'react';
-import {DndContext} from '@dnd-kit/core';
+import React from "react";
+import { DndContext } from "@dnd-kit/core";
 
 function App() {
   return (
@@ -30,8 +30,8 @@ function App() {
 You may also nest `<DndContext>` providers within other `<DndContext>` providers to achieve nested draggable/droppable interfaces that are independent of one another.
 
 ```jsx
-import React from 'react';
-import {DndContext} from '@dnd-kit/core';
+import React from "react";
+import { DndContext } from "@dnd-kit/core";
 
 function App() {
   return (
@@ -39,9 +39,7 @@ function App() {
       {/* Components that use `useDraggable`, `useDroppable` */}
       <DndContext>
         {/* ... */}
-        <DndContext>
-          {/* ... */}
-        </DndContext>
+        <DndContext>{/* ... */}</DndContext>
       </DndContext>
     </DndContext>
   );
@@ -56,20 +54,25 @@ If multiple `DndContext` providers are listening for the same event, events will
 
 ```typescript
 interface Props {
-  announcements?: Announcements;
-  autoScroll?: boolean;
+  id?: string;
+  accessibility?: {
+    announcements?: Announcements;
+    container?: Element;
+    restoreFocus?: boolean;
+    screenReaderInstructions?: ScreenReaderInstructions;
+  };
+  autoScroll?: boolean | AutoScrollOptions;
   cancelDrop?: CancelDrop;
   children?: React.ReactNode;
   collisionDetection?: CollisionDetection;
-  layoutMeasuring?: Partial<LayoutMeasuring>;
+  measuring?: MeasuringConfiguration;
   modifiers?: Modifiers;
-  screenReaderInstructions?: ScreenReaderInstructions;
   sensors?: SensorDescriptor<any>[];
   onDragStart?(event: DragStartEvent): void;
   onDragMove?(event: DragMoveEvent): void;
   onDragOver?(event: DragOverEvent): void;
   onDragEnd?(event: DragEndEvent): void;
-  onDragCancel?(): void;
+  onDragCancel?(event: DragCancelEvent): void;
 }
 ```
 
@@ -87,20 +90,20 @@ Fires when a drag event that meets the [activation constraints](../sensors/#conc
 
 Fires anytime as the [draggable](../draggable/) item is moved. Depending on the activated [sensor](../sensors/#activators), this could for example be as the [Pointer](../sensors/pointer.md) is moved or the [Keyboard](../sensors/keyboard.md) movement keys are pressed.
 
-#### `onDragOver` 
+#### `onDragOver`
 
 Fires when a [draggable](../draggable/) item is moved over a [droppable](../droppable/) container, along with the unique identifier of that droppable container.
 
-#### `onDragEnd` 
+#### `onDragEnd`
 
-Fires after a draggable item is dropped. 
+Fires after a draggable item is dropped.
 
-This event contains information about the active draggable `id` along with information on whether the draggable item was dropped `over`. 
+This event contains information about the active draggable `id` along with information on whether the draggable item was dropped `over`.
 
 If there are no [collisions detected](collision-detection-algorithms.md) when the draggable item is dropped, the `over` property will be `null`. If a collision is detected, the `over` property will contain the `id` of the droppable over which it was dropped.
 
 {% hint style="info" %}
-It's important to understand that the `onDragEnd` event **does not move** [**draggable**](../draggable/) **items into** [**droppable**](../droppable/) **containers.** 
+It's important to understand that the `onDragEnd` event **does not move** [**draggable**](../draggable/) **items into** [**droppable**](../droppable/) **containers.**
 
 Rather, it provides **information** about which draggable item was dropped and whether it was over a droppable container when it was dropped.
 
@@ -145,14 +148,14 @@ const defaultAnnouncements = {
   onDragCancel(id) {
     return `Dragging was cancelled. Draggable item ${id} was dropped.`;
   },
-}
+};
 ```
 
 While these default announcements are sensible defaults that should cover most simple use cases, you know your application best, and we highly recommend that you customize these to provide a screen reader experience that is more tailored to the use case you are building.
 
 #### Screen reader instructions
 
-Use the `screenReaderInstructions` prop to customize the instructions that are read to screen readers when the focus is moved 
+Use the `screenReaderInstructions` prop to customize the instructions that are read to screen readers when the focus is moved
 
 ### Autoscroll
 
@@ -162,15 +165,15 @@ Auto-scrolling may also be disabled on an individual sensor basis using the stat
 
 ### Collision detection
 
-Use the `collisionDetection` prop to customize the collision detection algorithm used to detect collisions between draggable nodes and droppable areas within the`DndContext` provider. 
+Use the `collisionDetection` prop to customize the collision detection algorithm used to detect collisions between draggable nodes and droppable areas within the`DndContext` provider.
 
 The default collision detection algorithm is the [rectangle intersection](collision-detection-algorithms.md#rectangle-intersection) algorithm.
 
 The built-in collision detection algorithms are:
 
-* [Rectangle intersection](collision-detection-algorithms.md#rectangle-intersection)
-* [Closest center](collision-detection-algorithms.md#closest-center)
-* [Closest corners](collision-detection-algorithms.md#closest-corners)
+- [Rectangle intersection](collision-detection-algorithms.md#rectangle-intersection)
+- [Closest center](collision-detection-algorithms.md#closest-center)
+- [Closest corners](collision-detection-algorithms.md#closest-corners)
 
 You may also build custom collision detection algorithms or compose existing ones.
 
@@ -180,7 +183,7 @@ To learn more, read the collision detection guide:
 
 ### Sensors
 
-Sensors are an abstraction to detect different input methods in order to initiate drag operations, respond to movement and end or cancel the operation. 
+Sensors are an abstraction to detect different input methods in order to initiate drag operations, respond to movement and end or cancel the operation.
 
 The default sensors used by `DndContext` are the [Pointer](../sensors/pointer.md) and [Keyboard](../sensors/keyboard.md) sensors.
 
@@ -192,10 +195,10 @@ To learn how to customize sensors or how to pass different sensors to `DndContex
 
 Modifiers let you dynamically modify the movement coordinates that are detected by sensors. They can be used for a wide range of use cases, for example:
 
-* Restricting motion to a single axis
-* Restricting motion to the draggable node container's bounding rectangle 
-* Restricting motion to the draggable node's scroll container bounding rectangle
-* Applying resistance or clamping the motion
+- Restricting motion to a single axis
+- Restricting motion to the draggable node container's bounding rectangle
+- Restricting motion to the draggable node's scroll container bounding rectangle
+- Applying resistance or clamping the motion
 
 To learn more about how to use Modifiers, read the Modifiers guide:
 
@@ -203,23 +206,22 @@ To learn more about how to use Modifiers, read the Modifiers guide:
 
 ### Layout measuring
 
-You can configure when and how often `DndContext`  should measure its droppable elements by using the `layoutMeasuring` prop. 
+You can configure when and how often `DndContext` should measure its droppable elements by using the `layoutMeasuring` prop.
 
 The `frequency` argument controls how frequently layouts should be measured. By default, layout measuring is set to `optimized`, which only measures layouts based on the `strategy`.
 
 Specify one of the following strategies:
 
-* `LayoutMeasuringStrategy.WhileDragging`: Default behavior, only measure droppable elements right after dragging has begun.
+- `LayoutMeasuringStrategy.WhileDragging`: Default behavior, only measure droppable elements right after dragging has begun.
 
-  `LayoutMeasuringStrategy.BeforeDragging`:  Measure droppable elements before dragging begins and right after it ends. 
+  `LayoutMeasuringStrategy.BeforeDragging`: Measure droppable elements before dragging begins and right after it ends.
 
-* `LayoutMeasuringStrategy.Always`: Measure droppable elements before dragging begins, right after dragging has begun, and after it ends.
+- `LayoutMeasuringStrategy.Always`: Measure droppable elements before dragging begins, right after dragging has begun, and after it ends.
 
 Example usage:
 
 ```jsx
-import {DndContext, LayoutMeasuringStrategy} from '@dnd-kit/core';
+import { DndContext, LayoutMeasuringStrategy } from "@dnd-kit/core";
 
-<DndContext layoutMeasuring={{strategy: LayoutMeasuringStrategy.Always}} />
+<DndContext layoutMeasuring={{ strategy: LayoutMeasuringStrategy.Always }} />;
 ```
-

--- a/api-documentation/context-provider/README.md
+++ b/api-documentation/context-provider/README.md
@@ -122,7 +122,7 @@ For more details and best practices around accessibility of draggable and droppa
 
 #### Announcements
 
-Use the `announcements` prop to customize the screen reader announcements that are announced in the live region when draggable items are picked up, moved over droppable regions, and dropped.
+Use the `accessibility.announcements` prop to customize the screen reader announcements that are announced in the live region when draggable items are picked up, moved over droppable regions, and dropped.
 
 The default announcements are:
 
@@ -155,7 +155,7 @@ While these default announcements are sensible defaults that should cover most s
 
 #### Screen reader instructions
 
-Use the `screenReaderInstructions` prop to customize the instructions that are read to screen readers when the focus is moved
+Use the `accessibility.screenReaderInstructions` prop to customize the instructions that are read to screen readers when the focus is moved
 
 ### Autoscroll
 

--- a/guides/accessibility.md
+++ b/guides/accessibility.md
@@ -16,12 +16,12 @@ The [Tools and Techniques](https://www.w3.org/WAI/people-use-web/tools-technique
 
 Some assistive technologies for the web include:
 
-* Screen readers
-* Voice control
-* Screen magnifiers
-* Input devices (such as the keyboard, pointers and switch devices)
+- Screen readers
+- Voice control
+- Screen magnifiers
+- Input devices (such as the keyboard, pointers and switch devices)
 
-When building accessible interfaces for the web, it's important to keep the three  following questions in mind:
+When building accessible interfaces for the web, it's important to keep the three following questions in mind:
 
 1. **Identity:** What element is the user interacting with?
 2. **Operation:** How can the user interact with the element?
@@ -37,13 +37,13 @@ The `@dnd-kit/core` library provides a number of sensible defaults to help you m
 
 These sensible defaults should be seen as _starting points_ rather than something you can set and forget; there is no one-size-fits-all solution to web accessibility.
 
-You know your application best, and while these sensible defaults will go a long way to help making your application more accessible, in most cases you'll want to customize these  so that they are tailored to the context of your application.
+You know your application best, and while these sensible defaults will go a long way to help making your application more accessible, in most cases you'll want to customize these so that they are tailored to the context of your application.
 
 The three main areas of focus for this guide to help you make your drag and drop interface more accessible are:
 
-* [Keyboard support](accessibility.md#keyboard-support)
-* [Screen reader instructions](accessibility.md#screen-reader-instructions)
-* [Live regions to provide screen reader announcements](accessibility.md#screen-reader-announcements-using-live-regions)
+- [Keyboard support](accessibility.md#keyboard-support)
+- [Screen reader instructions](accessibility.md#screen-reader-instructions)
+- [Live regions to provide screen reader announcements](accessibility.md#screen-reader-announcements-using-live-regions)
 
 ### Keyboard support
 
@@ -53,8 +53,8 @@ When creating widgets that a user can click or tap, drag, and drop, a user must 
 
 For drag and drop interfaces, this means that the activator element that initiates the drag action must:
 
-* Be able to receive focus
-* A user must be able to activate the action associated with the element using **both** the `enter` (on Windows) or `return` (on macOS) and the `space` key.
+- Be able to receive focus
+- A user must be able to activate the action associated with the element using **both** the `enter` (on Windows) or `return` (on macOS) and the `space` key.
 
 Both these guidelines should be respected to comply with the [third rule of ARIA](https://www.w3.org/TR/using-aria/#3rdrule).
 
@@ -66,8 +66,8 @@ In order for the Keyboard sensor to function properly, the activator element tha
 
 The `tabindex` attribute dictates the order in which focus moves throughout the document.
 
-* Natively interactive elements such as [buttons](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button), [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) and[ form controls ](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormControlsCollection)have a default `tabindex` value of `0`.&#x20;
-* Custom elements that are intended to be interactive and receive keyboard focus need to have an explicitly assigned `tabindex="0"`(for example, `div` and `li` elements)
+- Natively interactive elements such as [buttons](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button), [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) and[ form controls ](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormControlsCollection)have a default `tabindex` value of `0`.&#x20;
+- Custom elements that are intended to be interactive and receive keyboard focus need to have an explicitly assigned `tabindex="0"`(for example, `div` and `li` elements)
 
 In other words, in order for your draggable activator elements to be able to receive keyboard focus, they _need_ to have the `tabindex` attribute set to `0` **if** they are not natively interactive elements (such as the HTML `button` element).
 
@@ -87,7 +87,7 @@ The keyboard shortcuts of the Keyboard sensor can be [customized](../api-documen
 
 By default, the [Keyboard sensor](../api-documentation/sensors/keyboard.md) moves in any given direction by `25` pixels when the arrow keys are pressed while dragging.
 
-This is an arbitrary default that is likely not suited for all use-cases. We encourage you to customize this behaviour and tailor it to the context of your application using the  [`getNextCoordinates` option ](../api-documentation/sensors/keyboard.md#coordinates-getter)of the Keyboard sensor.
+This is an arbitrary default that is likely not suited for all use-cases. We encourage you to customize this behaviour and tailor it to the context of your application using the [`getNextCoordinates` option ](../api-documentation/sensors/keyboard.md#coordinates-getter)of the Keyboard sensor.
 
 For example, the `useSortable` hook ships with an augmented version of the Keyboard sensor that uses the `getNextCoordinates` option behind the scenes to find the coordinates of the next sortable element in any given direction when an arrow key is pressed.
 
@@ -95,11 +95,11 @@ In order to let users learn how to interact with draggable elements using these 
 
 ### Screen reader instructions
 
-In order to users know how to interact with draggable items using only the keyboard, it's important to provide information to the user that their focus is currently on a draggable item, along with clear instruction  on how to pick up a a draggable item, how to move it, how to drop it and how to cancel the operation.
+In order to users know how to interact with draggable items using only the keyboard, it's important to provide information to the user that their focus is currently on a draggable item, along with clear instruction on how to pick up a a draggable item, how to move it, how to drop it and how to cancel the operation.
 
 #### Role
 
-To let users know that their focus is currently on a draggable item, the [`useDraggable`](../api-documentation/draggable/usedraggable.md) hook provides the [`role`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) and [`aria-roledescription`](https://www.digitala11y.com/aria-roledescriptionproperties/), and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA\_Techniques/Using\_the\_aria-describedby\_attribute) attributes by default:
+To let users know that their focus is currently on a draggable item, the [`useDraggable`](../api-documentation/draggable/usedraggable.md) hook provides the [`role`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) and [`aria-roledescription`](https://www.digitala11y.com/aria-roledescriptionproperties/), and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attributes by default:
 
 | Attribute              | Default value             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -113,7 +113,7 @@ To customize the `aria-describedby` instructions, refer to the section below.
 
 #### Instructions
 
-By default, each  [`<DndContext>`](../api-documentation/context-provider/) component renders a unique HTML element that is rendered off-screen to be used to provide these instructions to screen readers.&#x20;
+By default, each [`<DndContext>`](../api-documentation/context-provider/) component renders a unique HTML element that is rendered off-screen to be used to provide these instructions to screen readers.&#x20;
 
 The default instructions are:
 
@@ -121,7 +121,7 @@ The default instructions are:
 > While dragging, use the arrow keys to move the item in any given direction.\
 > Press space or enter again to drop the item in its new position, or press escape to cancel.
 
-We recommend you customize and localize these instructions to your application and use-case using the `screenReaderInstructions` prop of [`<DndContext>`](../api-documentation/context-provider/). &#x20;
+We recommend you customize and localize these instructions to your application and use-case using the `draggable` key under the `accessibility.screenReaderInstructions` prop of [`<DndContext>`](../api-documentation/context-provider/). &#x20;
 
 For example, if you were building a sortable grocery shopping list, you may want to tailor the instructions like so:
 
@@ -133,39 +133,39 @@ If your application supports multiple languages, make sure you also translate th
 
 ### Screen reader announcements using live regions
 
-[Live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA\_Live\_Regions) are used to notify screen readers of content changes.&#x20;
+[Live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) are used to notify screen readers of content changes.&#x20;
 
 When building accessible drag and drop interfaces, live regions should be used to provide screen reader announcements in real-time of time-sensitive information of what is currently happening with draggable and droppable elements without having to move focus .
 
-By default, each  [`<DndContext>`](../api-documentation/context-provider/) component renders a unique HTML element that is rendered off-screen to be used for live screen-reader announcements of events like when a drag operation has started, when a draggable item has been dragged over a droppable container, when a drag operation has ended, and when a drag operation has been cancelled.
+By default, each [`<DndContext>`](../api-documentation/context-provider/) component renders a unique HTML element that is rendered off-screen to be used for live screen-reader announcements of events like when a drag operation has started, when a draggable item has been dragged over a droppable container, when a drag operation has ended, and when a drag operation has been cancelled.
 
-These instructions can be customized using the `announcements` prop of `DndContext`.
+These instructions can be customized using the `accessibility.announcements` prop of `DndContext`.
 
 The default announcements are:
 
 ```javascript
 const defaultAnnouncements = {
-  onDragStart({active}) {
+  onDragStart({ active }) {
     return `Picked up draggable item ${active.id}.`;
   },
-  onDragOver({active, over}) {
+  onDragOver({ active, over }) {
     if (over) {
       return `Draggable item ${active.id} was moved over droppable area ${over.id}.`;
     }
 
     return `Draggable item ${active.id} is no longer over a droppable area.`;
   },
-  onDragEnd({active, over}) {
+  onDragEnd({ active, over }) {
     if (over) {
       return `Draggable item ${active.id} was dropped over droppable area ${over.id}`;
     }
 
     return `Draggable item ${active.id} was dropped.`;
   },
-  onDragCancel({active}) {
+  onDragCancel({ active }) {
     return `Dragging was cancelled. Draggable item ${active.id} was dropped.`;
   },
-}
+};
 ```
 
 While these default announcements are sensible defaults that should cover most simple use cases, you know your application best, and we highly recommend that you customize these to provide a screen reader experience that is more tailored to the use case you are building.
@@ -180,7 +180,7 @@ Here's an example of index based announcements and why you should avoid them:
 Position based announcements are much more intuitive and natural:
 
 > Item at position 1 was picked up. Item was moved to position 2 of 5.
-{% endhint %}
+> {% endhint %}
 
 For example, when building a sortable list, you could write custom announcements that are tailored to that use-case using position based announcements:
 
@@ -189,7 +189,7 @@ function App() {
   const items = useState(['Apple', 'Orange', 'Strawberries', 'Raspberries']);
   const getPosition = (id) => items.indexOf(id) + 1; // prefer position over index
   const itemCount = items.length;
-  
+
   const announcements = {
     onDragStart({active}) {
       return `Picked up sortable item ${active.id}. Sortable item ${active.id} is in position ${getPosition(id)} of ${itemCount}`;
@@ -208,7 +208,7 @@ function App() {
       return `Dragging was cancelled. Sortable item ${active.id} was dropped.`;
     },
   };
-  
+
   return (
     <DndContext
       accessibility={

--- a/guides/accessibility.md
+++ b/guides/accessibility.md
@@ -129,6 +129,26 @@ For example, if you were building a sortable grocery shopping list, you may want
 > Use the up and down arrow keys to update the position of the item in the grocery list.\
 > Press space or enter again to drop the item in its new position, or press escape to cancel.
 
+```javascript
+function App() {
+  /* ... */
+
+  const instructions = `
+  To pick up a grocery list item, press space or enter.
+  Use the up and down arrow keys to update the position of the item in the grocery list.
+  Press space or enter again to drop the item in its new position, or press escape to cancel.
+  `
+
+  return (
+    <DndContext
+      accessibility={{
+        screenReaderInstructions: {
+          draggable: instructions,
+        },
+      }}
+    >
+```
+
 If your application supports multiple languages, make sure you also translate these instructions. The `<DndContext>` component only ships with instructions in English due to bundle size concerns.
 
 ### Screen reader announcements using live regions


### PR DESCRIPTION
Apologies for the Prettier churn, this is a smaller change than it appears. Similarly to #14, I noticed that the Accessibility guide doesn't reflect the DndContext prop type update.

This PR makes the following changes:
- Update the Props definition in _api-documentation/context-provider_ to reflect the [current version](https://github.com/clauderic/dnd-kit/blob/master/packages/core/src/components/DndContext/DndContext.tsx#L88).
- Change DndContext prop references in _guides/accessibility_ to `accessibility.[propName]` so it's clearer they belong in an object under the `accessibility` prop.
- Add an example to the screen reader instructions section of _guides/accessibility_ so users have a clearer idea of how to customize instructions.

This is my first ever contribution, so I'm more than happy to accept feedback. :)

Many thanks to the maintainers of this library! It's been a godsend for my project, and I really appreciate how a11y was taken into account. Hopefully these changes can help make it easier for newer devs like me to implement 👍 