### PR TITLE
Fix the sortable with DragOverlay example

### DIFF
--- a/presets/sortable/README.md
+++ b/presets/sortable/README.md
@@ -743,9 +743,13 @@ export function SortableItem(props) {
   };
   
   return (
-    <Item ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {value}
-    </Item>
+    <Item
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      {...props}
+    />
   );
 }
 ```


### PR DESCRIPTION
The current example passes children to `Item` when it wants `id`