### PR TITLE
fix: corrects example usage of accessibility prop with custom announcements

### DIFF
--- a/guides/accessibility.md
+++ b/guides/accessibility.md
@@ -211,9 +211,9 @@ function App() {
   
   return (
     <DndContext
-      accessibility={
+      accessibility={{
         announcements,
-      }
+      }}
     >
 ```
 


### PR DESCRIPTION
In this example page for writing your own custom screen reader announcements, the docs are missing a set of curly braces. The specification for the `accessibility` prop is that it is an object which can have an `announcements` key. That would require you to write code like this:

```
accessibility={{
  announcements,
}}
```

Instead, the docs show only one set of curly braces, indicating that the `accessibility` prop is just an object with properties like `onDragStart`, `onDragMove`, `onDragOver`, `onDragEnd`, and `onDragCancel`, which is incorrect.

```
accessibility={
  announcements,
}
```

Hope this helps!