### PR TITLE
made change in dnd kit documentation for the autoScroll prop

### DIFF
--- a/api-documentation/context-provider/README.md
+++ b/api-documentation/context-provider/README.md
@@ -57,7 +57,7 @@ If multiple `DndContext` providers are listening for the same event, events will
 ```typescript
 interface Props {
   announcements?: Announcements;
-  autoScroll?: boolean;
+  autoScroll?: boolean | AutoScrollOptions;
   cancelDrop?: CancelDrop;
   children?: React.ReactNode;
   collisionDetection?: CollisionDetection;
@@ -70,6 +70,20 @@ interface Props {
   onDragOver?(event: DragOverEvent): void;
   onDragEnd?(event: DragEndEvent): void;
   onDragCancel?(): void;
+}
+
+interface AutoScrollOptions {
+  acceleration?: number;
+  activator?: AutoScrollActivator;
+  canScroll?: CanScroll;
+  enabled?: boolean;
+  interval?: number;
+  layoutShiftCompensation?: boolean | {x: boolean, y: boolean};
+  order?: TraversalOrder;
+  threshold?: {
+    x: number;
+    y: number;
+  };
 }
 ```
 
@@ -156,7 +170,7 @@ Use the `screenReaderInstructions` prop to customize the instructions that are r
 
 ### Autoscroll
 
-Use the optional `autoScroll` boolean prop to temporarily or permanently disable auto-scrolling for all sensors used within this `DndContext`.
+Use the optional `autoScroll` prop to temporarily or permanently disable auto-scrolling for all sensors used within this `DndContext`.
 
 Auto-scrolling may also be disabled on an individual sensor basis using the static property `autoScrollEnabled` of the sensor. For example, the [Keyboard sensor](../sensors/keyboard.md) manages scrolling internally, and therefore has the static property `autoScrollEnabled` set to `false`.
 


### PR DESCRIPTION
The auto scroll is not a boolean prop only, it takes an AutoScrollOptions as its value as well so just updating the readme for the same , as it's a bit confusing for the users that it takes only boolean value whereas it is open to so many options.
For eg, using the canScroll option user can limit the scroll to a specific container.