### PR TITLE
Fix error in sensors/keyboard example code

### DIFF
--- a/api-documentation/sensors/keyboard.md
+++ b/api-documentation/sensors/keyboard.md
@@ -58,22 +58,22 @@ function customCoordinatesGetter(event, args) {
   const delta = 50;
   
   switch (event.code) {
-    case 'Right':
+    case 'ArrowRight':
       return {
         ...currentCoordinates,
         x: currentCoordinates.x + delta,
       };
-    case 'Left':
+    case 'ArrowLeft':
       return {
         ...currentCoordinates,
         x: currentCoordinates.x - delta,
       };
-    case 'Down':
+    case 'ArrowDown':
       return {
         ...currentCoordinates,
         y: currentCoordinates.y + delta,
       };
-    case 'Up':
+    case 'ArrowUp':
       return {
         ...currentCoordinates,
         y: currentCoordinates.y - delta,


### PR DESCRIPTION
event.code returns ArrowLeft, ArrowUp, etc.
Fixed the error in this demo.