### PR TITLE
doc: fix missing quotation in example code

### DIFF
--- a/presets/sortable/sortable-context.md
+++ b/presets/sortable/sortable-context.md
@@ -82,9 +82,9 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Good, nested DndContexts
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
     <DndContext>
-      <SortableContext items={["A, "B", "C"]}>
+      <SortableContext items={["A", "B", "C"]}>
         {/* ... */}
       </SortableContext>
     </DndContext>
@@ -93,8 +93,8 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Bad, nested Sortable contexts with `id` collisions
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
-    <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
+    <SortableContext items={["A", "B", "C"]}>
       {/* ... */}
     </SortableContext>
   </SortableContext>
@@ -102,7 +102,7 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Good, nested Sortable contexts with unique `id`s
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
     <SortableContext items={[1, 2, 3]}>
       {/* ... */}
     </SortableContext>


### PR DESCRIPTION

This pull request includes minor corrections to the `presets/sortable/sortable-context.md` file. The changes fix typographical errors in the `items` arrays within `SortableContext` examples.

Typographical corrections:

* [`presets/sortable/sortable-context.md`](diffhunk://#diff-f4cc15d572cd1f77e56022478cabf13260e4eaffc4d7297f2f5c6a816f2a4fabL85-R87): Corrected the `items` arrays by adding missing quotation marks in the nested `SortableContext` examples. [[1]](diffhunk://#diff-f4cc15d572cd1f77e56022478cabf13260e4eaffc4d7297f2f5c6a816f2a4fabL85-R87) [[2]](diffhunk://#diff-f4cc15d572cd1f77e56022478cabf13260e4eaffc4d7297f2f5c6a816f2a4fabL96-R105)